### PR TITLE
Eliminate race condition to improve coordinate accuracy and reliability.

### DIFF
--- a/adafruit_touchscreen.py
+++ b/adafruit_touchscreen.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2019 ladyada for Adafruit Industries
 #
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: MITx
 
 """
 `adafruit_touchscreen`


### PR DESCRIPTION
Was experiencing occasional touch coordinate errors, particularly when rapidly pressing the touchscreen. The existing code measured the x and y coordinates then would check to see if the z (pressed) value exceeded the touch threshold value. In some cases, the x and/or y coordinate value would reflect a measurement made before or while the screen was being pressed, resulting in a significant coordinate offset error even when averaged.

The modification consists of two changes. First, the x and y values are not measured until after the z value exceeds the threshold, assuring coordinate accuracy and stability. Second, the z value is sampled and averaged to reduce spurious triggering.

Tests without the changes experienced approximately 2 errors per 50 presses. The error rate dropped to 0 with the updated code.

Tests were performed using CircuitPython 7.0.0 on a PyPortal Titano using DisplayIO Buttons and VectorIO objects.

