### PR TITLE
Remove debug artifact

### DIFF
--- a/adafruit_touchscreen.py
+++ b/adafruit_touchscreen.py
@@ -108,7 +108,6 @@ class Touchscreen:
         self._rx_plate = x_resistance
         self._xsamples = [0] * samples
         self._ysamples = [0] * samples
-        self._zsamples = [0] * samples
         if not calibration:
             calibration = ((0, 65535), (0, 65535))
         self._calib = calibration


### PR DESCRIPTION
Removed a remnant of the z-axis sampling test. Z-axis sampling was not necessary for reliable operation.